### PR TITLE
same semantic in the help message than in the code

### DIFF
--- a/runtests_server.sh
+++ b/runtests_server.sh
@@ -7,8 +7,8 @@ set -o pipefail
 if [[ $# -lt 2 || ( "$1" != benchmark && "$1" != "test" ) ]];
 then
     echo "Usage: "
-    echo "  $0 benchmark name [server_branch[:rev_number]] [web_branch[:rev_number]] [tag]"
-    echo "  $0 test name [server_branch[:rev_number]] [web_branch[:rev_number]] [tag]"
+    echo "  $0 benchmark name [server_branch[/rev_number]] [web_branch[/rev_number]] [tag]"
+    echo "  $0 test name [server_branch[/rev_number]] [web_branch[/rev_number]] [tag]"
     exit 1
 fi
 


### PR DESCRIPTION
In the code I read that "/" character must be used to select an specific revision, use the same character in the usage message